### PR TITLE
ci: add CI workflow using ippoan/ci-workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: ippoan/ci-workflows/.github/workflows/frontend-ci.yml@main
+    with:
+      has_tests: true
+      typecheck_command: 'npx tsc --noEmit'
+      post_install_script: 'npx wrangler types'
+      test_command: 'npx vitest run --coverage'
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
   ci:
     uses: ippoan/ci-workflows/.github/workflows/frontend-ci.yml@main
     with:
+      project_type: worker
       has_tests: true
-      typecheck_command: 'npx tsc --noEmit'
       post_install_script: 'npx wrangler types'
       test_command: 'npx vitest run --coverage'
     secrets: inherit

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -45,5 +45,10 @@
 	"vars": {
 		"CLOUDFLARE_API_TOKEN": "",
 		"CLOUDFLARE_ZONE_ID": ""
+	},
+	"env": {
+		"staging": {
+			"name": "security-notification-app-staging"
+		}
 	}
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,6 +5,7 @@
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "security-notification-app",
+	"account_id": "24b45709d060d957340180e995f0d373",
 	"main": "src/index.ts",
 	"compatibility_date": "2024-12-01",
 	"migrations": [

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -41,14 +41,9 @@
 	],
 	"observability": {
 		"enabled": true
+	},
+	"vars": {
+		"CLOUDFLARE_API_TOKEN": "",
+		"CLOUDFLARE_ZONE_ID": ""
 	}
-	/**
-	 * Environment Variables - Set these via wrangler secret or in dashboard
-	 * CLOUDFLARE_API_TOKEN: Your Cloudflare API token with read access to security events
-	 * CLOUDFLARE_ZONE_ID: The zone ID to monitor for security events
-	 */
-	// "vars": { 
-	//   "CLOUDFLARE_API_TOKEN": "your-api-token",
-	//   "CLOUDFLARE_ZONE_ID": "your-zone-id"
-	// }
 }


### PR DESCRIPTION
## Summary
- ippoan org に移動 (ohishi-yhonda-pub → ippoan)
- ci-workflows reusable workflow で CI 追加 (test+typecheck+deploy)
- wrangler.jsonc に account_id 追加