### PR TITLE
feat: always send email + move from/to to vars

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
 import { DurableObject, WorkerEntrypoint, RpcTarget } from "cloudflare:workers";
 
-const EMAIL_FROM = "security-alert@mtamaramu.com";
-const EMAIL_TO = "m.tama.ramu@gmail.com";
-
 interface NotificationEndpoint {
 	id: string;
 	name: string;
@@ -163,9 +160,15 @@ export class NotificationManager extends DurableObject<Env> {
 	}
 
 	async sendNotificationsBatch(events: SecurityEvent[]): Promise<void> {
+		if (events.length === 0) return;
+
+		// Email は endpoint 登録に依存せず常に送る (NOTIFY_EMAIL_TO 宛)
+		await this.sendEmailBatch(events).catch(err =>
+			console.error('Failed to send email batch:', err)
+		);
+
 		const endpoints = await this.getEndpoints();
 		const activeEndpoints = endpoints.filter(ep => ep.enabled);
-
 		await this.sendToEndpointsBatch(activeEndpoints, events);
 	}
 
@@ -173,6 +176,8 @@ export class NotificationManager extends DurableObject<Env> {
 		if (events.length === 0) return;
 
 		// Send to each endpoint with all events in a single notification
+		// (email は sendNotificationsBatch で env vars 宛に常時送信されるため、
+		// endpoint type 'email' は no-op として無視する)
 		const promises = endpoints.map(endpoint => {
 			switch (endpoint.type) {
 				case 'webhook':
@@ -184,9 +189,7 @@ export class NotificationManager extends DurableObject<Env> {
 						console.error(`Failed to send batch to Slack ${endpoint.name}:`, err)
 					);
 				case 'email':
-					return this.sendEmailBatch(events).catch(err =>
-						console.error(`Failed to send email batch to ${endpoint.name}:`, err)
-					);
+					return Promise.resolve();
 			}
 		});
 
@@ -359,13 +362,16 @@ ${moreNote}
 		const { EmailMessage } = await import("cloudflare:email");
 		const { createMimeMessage } = await import("mimetext");
 
+		const from = this.env.NOTIFY_EMAIL_FROM;
+		const to = this.env.NOTIFY_EMAIL_TO;
+
 		const msg = createMimeMessage();
-		msg.setSender({ name: "CF Security Notifier", addr: EMAIL_FROM });
-		msg.setRecipient(EMAIL_TO);
+		msg.setSender({ name: "CF Security Notifier", addr: from });
+		msg.setRecipient(to);
 		msg.setSubject(subject);
 		msg.addMessage({ contentType: "text/html", data: html });
 
-		const emailMessage = new EmailMessage(EMAIL_FROM, EMAIL_TO, msg.asRaw());
+		const emailMessage = new EmailMessage(from, to, msg.asRaw());
 		await this.env.EMAIL.send(emailMessage);
 	}
 

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -6,6 +6,8 @@ declare namespace Cloudflare {
 		PROCESSED_EVENTS: KVNamespace;
 		CLOUDFLARE_API_TOKEN: string;
 		CLOUDFLARE_ZONE_ID: string;
+		NOTIFY_EMAIL_FROM: string;
+		NOTIFY_EMAIL_TO: string;
 		NOTIFICATION_MANAGER: DurableObjectNamespace<import("./src/index").NotificationManager>;
 		EMAIL: SendEmail;
 	}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -50,7 +50,9 @@
 	},
 	"vars": {
 		"CLOUDFLARE_API_TOKEN": "",
-		"CLOUDFLARE_ZONE_ID": ""
+		"CLOUDFLARE_ZONE_ID": "",
+		"NOTIFY_EMAIL_FROM": "security-alert@mtamaramu.com",
+		"NOTIFY_EMAIL_TO": "m.tama.ramu@gmail.com"
 	},
 	"secrets": {
 		"required": []
@@ -81,7 +83,9 @@
 			],
 			"vars": {
 				"CLOUDFLARE_API_TOKEN": "",
-				"CLOUDFLARE_ZONE_ID": ""
+				"CLOUDFLARE_ZONE_ID": "",
+				"NOTIFY_EMAIL_FROM": "security-alert@mtamaramu.com",
+				"NOTIFY_EMAIL_TO": "m.tama.ramu@gmail.com"
 			},
 			"secrets": {
 				"required": []


### PR DESCRIPTION
[no-issue]

## Summary

#9 で実装した email 通知の挙動を 2 点変更:

1. **endpoint 登録に依存せず常に送る** — `sendNotificationsBatch` 冒頭で `sendEmailBatch` を必ず呼ぶ。endpoint type `'email'` は no-op に (二重送信防止)。webhook / slack は従来通り endpoint 登録 driven
2. **From / To をハードコード → `vars`** — `NOTIFY_EMAIL_FROM` / `NOTIFY_EMAIL_TO` を `wrangler.jsonc` の `vars` に移動。`worker-configuration.d.ts` の `Env` にも追加

## Test plan

- [x] `npx tsc --noEmit` — 通過
- [x] `npm test` — 55/55 passed
- [ ] deploy 後、cron run で `m.tama.ramu@gmail.com` (= `NOTIFY_EMAIL_TO`) にメールが届くこと (endpoint 未登録の状態で)

## Notes

- `[[send_email]]` の `destination_address` は引き続き `m.tama.ramu@gmail.com` で pin。To アドレスを vars だけで変えると Email Routing 側で reject されるため、変更時は両方連動して update が必要
- 別 branch (`-2`) で出している理由: 前回 PR #9 の squash merge 後、同名 remote branch との履歴が分岐したため (force push 回避)


---
_Generated by [Claude Code](https://claude.ai/code/session_01R7wDdV7L71C6xcgjR4F9n6)_