### PR TITLE
fix: wire CLOUDFLARE_API_TOKEN via Secrets Store, support multi-zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,24 @@ npm install
 wrangler kv:namespace create "PROCESSED_EVENTS"
 ```
 
-3. シークレットを設定:
-```bash
-wrangler secret put CLOUDFLARE_API_TOKEN
-wrangler secret put CLOUDFLARE_ZONE_ID
+3. zone ID を設定 (zone ID は機密ではないので plain vars に直書き):
+```jsonc
+// wrangler.jsonc
+"vars": {
+  "CLOUDFLARE_ZONE_IDS": "<zone-id-1>,<zone-id-2>"
+}
 ```
 
-4. `wrangler.jsonc`にKV名前空間IDを設定
+4. API token を CF Secrets Store に投入 (値は context に出さない):
+```bash
+# Cloudflare dashboard で zone analytics:read 権限の API token を発行してから:
+echo -n '<token値>' | bash ~/.claude/skills/secret-inject/scripts/inject-secret.sh \
+  security-notification-app-cf-api-token --targets gcp,cf
+```
+
+CF Secrets Store の `bd7bc91a3e5f4111add4acf6cb4b8733/security-notification-app-cf-api-token` に入り、`wrangler.jsonc` の `secrets_store_secrets` binding 経由で `env.CLOUDFLARE_API_TOKEN.get()` から読める。
+
+5. `wrangler.jsonc`にKV名前空間IDを設定
 
 5. デプロイ:
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,16 @@
 import { DurableObject, WorkerEntrypoint, RpcTarget } from "cloudflare:workers";
 
+// CF Secrets Store binding (`secrets_store_secrets`) is exposed in production
+// as an object with async `.get()`. In vitest (miniflare lacks a Secrets Store
+// provider) we inject a plain string via `bindings: { CLOUDFLARE_API_TOKEN: "..." }`,
+// so the helper accepts both shapes.
+type SecretsStoreBinding = { get(): Promise<string> };
+
+async function readApiToken(env: Env): Promise<string> {
+	const t = (env as unknown as { CLOUDFLARE_API_TOKEN: SecretsStoreBinding | string }).CLOUDFLARE_API_TOKEN;
+	return typeof t === 'string' ? t : await t.get();
+}
+
 interface NotificationEndpoint {
 	id: string;
 	name: string;
@@ -88,9 +99,17 @@ export class NotificationManager extends DurableObject<Env> {
 	}
 
 	private async fetchSecurityEvents(startTime: Date, endTime: Date): Promise<SecurityEvent[]> {
+		const zoneIds = this.env.CLOUDFLARE_ZONE_IDS
+			.split(',')
+			.map((s) => s.trim())
+			.filter(Boolean);
+
+		const apiToken = await readApiToken(this.env);
+		const zoneTagsLiteral = JSON.stringify(zoneIds);
+
 		const query = `query {
 			viewer {
-				zones(filter: { zoneTag: "${this.env.CLOUDFLARE_ZONE_ID}" }) {
+				zones(filter: { zoneTag_in: ${zoneTagsLiteral} }) {
 					firewallEventsAdaptive(
 						filter: {
 							datetime_geq: "${startTime.toISOString()}"
@@ -119,7 +138,7 @@ export class NotificationManager extends DurableObject<Env> {
 		const response = await fetch('https://api.cloudflare.com/client/v4/graphql', {
 			method: 'POST',
 			headers: {
-				'Authorization': `Bearer ${this.env.CLOUDFLARE_API_TOKEN}`,
+				'Authorization': `Bearer ${apiToken}`,
 				'Content-Type': 'application/json',
 			},
 			body: JSON.stringify({ query }),
@@ -135,7 +154,8 @@ export class NotificationManager extends DurableObject<Env> {
 			throw new Error(`GraphQL error: ${data.errors[0].message}`);
 		}
 
-		const events = data.data?.viewer?.zones?.[0]?.firewallEventsAdaptive ?? [];
+		const zones = data.data?.viewer?.zones ?? [];
+		const events = zones.flatMap((zone: any) => zone.firewallEventsAdaptive ?? []);
 
 		return events.map((event: any) => ({
 			id: event.rayName,

--- a/test/edge-cases.test.ts
+++ b/test/edge-cases.test.ts
@@ -6,7 +6,7 @@ import { createGraphQLSecurityResponse } from './helpers/test-helpers';
 // Type assertion for env with required properties
 const testEnv = env as typeof env & {
 	CLOUDFLARE_API_TOKEN: string;
-	CLOUDFLARE_ZONE_ID: string;
+	CLOUDFLARE_ZONE_IDS: string;
 };
 
 // Mock global fetch
@@ -19,7 +19,7 @@ describe('Edge Cases and Error Handling', () => {
 		worker = createRPCWorker(testEnv);
 		vi.clearAllMocks();
 		testEnv.CLOUDFLARE_API_TOKEN = 'test-token';
-		testEnv.CLOUDFLARE_ZONE_ID = 'test-zone-id';
+		testEnv.CLOUDFLARE_ZONE_IDS = 'test-zone-id-1,test-zone-id-2';
 	});
 
 	describe('Webhook error handling', () => {
@@ -395,6 +395,43 @@ describe('Edge Cases and Error Handling', () => {
 			const result = await worker.sendTestNotification(testEvent);
 			expect(result.success).toBe(true);
 			expect(result.notifiedEndpoints).toBe(3); // All 3 active endpoints attempted
+		});
+	});
+
+	describe('Multi-zone aggregation', () => {
+		it('should aggregate events from multiple zones (flatMap)', async () => {
+			(global.fetch as any).mockImplementationOnce(async () =>
+				new Response(JSON.stringify({
+					data: {
+						viewer: {
+							zones: [
+								{ firewallEventsAdaptive: [{
+									rayName: 'zone1-event', datetime: new Date().toISOString(),
+									action: 'block', clientIP: '1.1.1.1', clientCountry: 'US',
+									clientRequestHTTPMethodName: 'GET', clientRequestHTTPHost: 'a.example.com',
+									clientRequestPath: '/', userAgent: 'UA', ruleId: 'r1', description: 'd1',
+								}] },
+								{ firewallEventsAdaptive: [{
+									rayName: 'zone2-event', datetime: new Date().toISOString(),
+									action: 'challenge', clientIP: '2.2.2.2', clientCountry: 'JP',
+									clientRequestHTTPMethodName: 'POST', clientRequestHTTPHost: 'b.example.com',
+									clientRequestPath: '/x', userAgent: 'UA', ruleId: 'r2', description: 'd2',
+								}] },
+							]
+						}
+					}
+				}), { status: 200 })
+			);
+			const result = await worker.checkSecurityEvents();
+			expect(result.success).toBe(true);
+		});
+
+		it('should handle missing zones array (zones undefined)', async () => {
+			(global.fetch as any).mockImplementationOnce(async () =>
+				new Response(JSON.stringify({ data: { viewer: {} } }), { status: 200 })
+			);
+			const result = await worker.checkSecurityEvents();
+			expect(result.success).toBe(true);
 		});
 	});
 

--- a/test/helpers/test-helpers.ts
+++ b/test/helpers/test-helpers.ts
@@ -1,10 +1,13 @@
 import { vi } from 'vitest';
 import { env } from 'cloudflare:test';
 
-// Type assertion for env with required properties
+// Type assertion for env with required properties.
+// In vitest miniflare we inject a plain string for the secret binding via
+// `bindings:` in vitest.config.ts, so the helper-level type is `string`.
+// Production type (object with async `.get()`) is normalised by `readApiToken()`.
 export const testEnv = env as typeof env & {
 	CLOUDFLARE_API_TOKEN: string;
-	CLOUDFLARE_ZONE_ID: string;
+	CLOUDFLARE_ZONE_IDS: string;
 	NOTIFICATION_MANAGER: DurableObjectNamespace;
 	PROCESSED_EVENTS: KVNamespace;
 };
@@ -115,9 +118,10 @@ export function mockDurableObjectStub() {
 	};
 }
 
-// Setup test environment
+// Setup test environment (binding 値は vitest.config.ts の miniflare.bindings で
+// 既に inject 済み。setupTestEnvironment は fetch mock の reset と互換のため残す)
 export function setupTestEnvironment() {
 	testEnv.CLOUDFLARE_API_TOKEN = 'test-token';
-	testEnv.CLOUDFLARE_ZONE_ID = 'test-zone-id';
+	testEnv.CLOUDFLARE_ZONE_IDS = 'test-zone-id-1,test-zone-id-2';
 	mockFetch();
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,13 @@ export default defineWorkersConfig({
 					// Required to use `SELF.scheduled()`. This is an experimental
 					// compatibility flag, and cannot be enabled in production.
 					compatibilityFlags: ["service_binding_extra_handlers"],
+					// miniflare はまだ secrets_store_secrets を natively support して
+					// いないので、test では plain string で override する。
+					// src 側の `readApiToken()` が string / { get() } 両方を normalize する。
+					bindings: {
+						CLOUDFLARE_API_TOKEN: "test-token",
+						CLOUDFLARE_ZONE_IDS: "test-zone-id-1,test-zone-id-2",
+					},
 				},
 			}
 		},

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -4,8 +4,11 @@
 declare namespace Cloudflare {
 	interface Env {
 		PROCESSED_EVENTS: KVNamespace;
-		CLOUDFLARE_API_TOKEN: string;
-		CLOUDFLARE_ZONE_ID: string;
+		// CF Secrets Store binding in production (object with async `.get()`).
+		// In vitest miniflare we inject a plain string via `bindings:`, so the
+		// type accepts both shapes and `readApiToken()` normalises.
+		CLOUDFLARE_API_TOKEN: SecretsStoreSecret | string;
+		CLOUDFLARE_ZONE_IDS: string;
 		NOTIFY_EMAIL_FROM: string;
 		NOTIFY_EMAIL_TO: string;
 		NOTIFICATION_MANAGER: DurableObjectNamespace<import("./src/index").NotificationManager>;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -49,14 +49,17 @@
 		"enabled": true
 	},
 	"vars": {
-		"CLOUDFLARE_API_TOKEN": "",
-		"CLOUDFLARE_ZONE_ID": "",
+		"CLOUDFLARE_ZONE_IDS": "2eb0f540aaf601916d2749c88ad005aa,f95be7b0a4ca5b49ed6ca5dd448511b0",
 		"NOTIFY_EMAIL_FROM": "security-alert@mtamaramu.com",
 		"NOTIFY_EMAIL_TO": "m.tama.ramu@gmail.com"
 	},
-	"secrets": {
-		"required": []
-	},
+	"secrets_store_secrets": [
+		{
+			"binding": "CLOUDFLARE_API_TOKEN",
+			"store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
+			"secret_name": "security-notification-app-cf-api-token"
+		}
+	],
 	"env": {
 		"staging": {
 			"name": "security-notification-app-staging",
@@ -82,14 +85,17 @@
 				}
 			],
 			"vars": {
-				"CLOUDFLARE_API_TOKEN": "",
-				"CLOUDFLARE_ZONE_ID": "",
+				"CLOUDFLARE_ZONE_IDS": "2eb0f540aaf601916d2749c88ad005aa,f95be7b0a4ca5b49ed6ca5dd448511b0",
 				"NOTIFY_EMAIL_FROM": "security-alert@mtamaramu.com",
 				"NOTIFY_EMAIL_TO": "m.tama.ramu@gmail.com"
 			},
-			"secrets": {
-				"required": []
-			}
+			"secrets_store_secrets": [
+				{
+					"binding": "CLOUDFLARE_API_TOKEN",
+					"store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
+					"secret_name": "security-notification-app-cf-api-token"
+				}
+			]
 		}
 	}
 }


### PR DESCRIPTION
## Summary

本番 cron が `*/5 * * * *` で 12 回連続 `Cloudflare GraphQL API error: 400` で fail し email 通知が一切飛んでいなかった問題を修正する (Refs #11 handoff)。

- `CLOUDFLARE_API_TOKEN` を **CF Secrets Store binding** に切替 (cf-billing-monitor と同じパターン)。`bd7bc91a3e5f4111add4acf6cb4b8733` / `security-notification-app-cf-api-token`
- `CLOUDFLARE_ZONE_IDS` を **plain vars 直書き** (comma-separated)。zone ID は機密ではないため (cf-billing-monitor の `CF_ACCOUNT_ID` と同じ判断)
- GraphQL を `zoneTag` → `zoneTag_in: [...]` に変更し、**複数 zone から firewall events を flatMap で aggregate**
- src 側に `readApiToken()` helper を追加。本番 (`SecretsStoreSecret`) と vitest miniflare (plain string) の両形を normalize (HCReaderWorker と同パターン)
- `vitest.config.ts` の `miniflare.bindings` で test 値を inject — miniflare は `secrets_store_secrets` を natively support していないため
- multi-zone aggregation + zones undefined fallback の test を追加 (57 tests pass)

## Test plan

- [x] `npx tsc --noEmit` (typecheck clean)
- [x] `npm test` — 57/57 pass
- [x] `npm run test:coverage` — 92.63% (baseline 90% 台維持、削除は無し)
- [ ] merge 後、CI deploy 完了を確認
- [ ] CF Secrets Store に `security-notification-app-cf-api-token` を投入 (= Cloudflare dashboard で zone analytics:read 権限の API token を発行し、`secret-inject` skill 経由で `gcp,cf` 両 target に投入)
- [ ] 投入後 5 分以内に次の cron が走り、`cf_logging` MCP で 400 error が消えること + email が届くことを確認

## 残課題 (この PR では扱わない)

- API token の値そのもの投入は **user 側 (or 後続セッション) で実行**: 値は `secret-inject` skill 経由で context に出さず投入する必要がある
- 投入が完了するまで cron は引き続き fail する (= 値が無いと `Bearer ` が空で送られ CF が 401)。worker code 側は今回の変更で **値が rotate された瞬間に自動復旧**する

Refs #11

https://claude.ai/code/session_01RwZm9s4kqbHQZ12fc9LjhG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwZm9s4kqbHQZ12fc9LjhG)_