### PR TITLE
ci: add deploy_staging_script/deploy_release_script (Refs #11)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,10 @@ jobs:
       has_tests: true
       post_install_script: 'npx wrangler types'
       test_command: 'npx vitest run --coverage'
+      # main push (= PR merge) で staging env (`security-notification-app-staging`) へ
+      # 自動 deploy。tag push (`v*`) で root config (= prod `security-notification-app`)
+      # へ deploy。caller で deploy_*_script を指定しないと frontend-ci.yml は deploy
+      # job 自体を skip する (cf-billing-monitor / HCReaderWorker と同じ pattern)。
+      deploy_staging_script: 'npx wrangler deploy --env staging'
+      deploy_release_script: 'npx wrangler deploy'
     secrets: inherit


### PR DESCRIPTION
## Summary

PR #12 を merge したが、main の CI run で **Deploy Staging / Deploy Release / Publish Dev / Publish Release / Propagate Package がすべて `skipped`** され、prod Worker が更新されないことが判明。dashboard の `Variables and secrets` も古い `Plaintext / CLOUDFLARE_API_TOKEN (空)` のままで、cron は依然 400 で fail し続けていた (cf_logging で 06:45 UTC まで確認)。

原因: `frontend-ci.yml` reusable は caller の `deploy_*_script` input が未指定だと deploy job 自体を skip する仕様 (cf-billing-monitor / HCReaderWorker / secrets-inventory はすべて指定済み)。

修正: caller (`.github/workflows/test.yml`) に 2 行追加:

- `deploy_staging_script: 'npx wrangler deploy --env staging'` — main push (= PR merge) で staging env (`security-notification-app-staging`) を更新
- `deploy_release_script: 'npx wrangler deploy'` — `v*` tag push で root config (prod) を更新

## Test plan

- [x] CI Type Check / Vitest (前回 green、本 PR は workflow yaml だけ touch)
- [ ] merge 後の main CI で Deploy Staging が **success** で完了することを確認
- [ ] その後 5 分以内の cron で `cf_logging` の error fingerprint `1561eb1294d0307fec890e38fd1baa38` (400 error) が消失することを確認
- [ ] 受信箱で `m.tama.ramu@gmail.com` 宛にメール到着 (events 検出時)

## なぜ #12 で気付けなかったか

#12 の PR run は `Deploy Staging` を含むがそれも skipped だった (PR commit のみだから当然と判断してスルーした)。実際はこの caller には deploy 設定が**最初から無く**、merge 後の main run でも skip される構造的問題だった。今回の修正で main push と tag push の deploy 経路が両方とも有効化される。

Refs #11

https://claude.ai/code/session_01RwZm9s4kqbHQZ12fc9LjhG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwZm9s4kqbHQZ12fc9LjhG)_