### PR TITLE
refactor: collapse to single-env (staging = prod) (Refs #11)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
       has_tests: true
       post_install_script: 'npx wrangler types'
       test_command: 'npx vitest run --coverage'
-      # main push (= PR merge) で staging env (`security-notification-app-staging`) へ
-      # 自動 deploy。tag push (`v*`) で root config (= prod `security-notification-app`)
-      # へ deploy。caller で deploy_*_script を指定しないと frontend-ci.yml は deploy
-      # job 自体を skip する (cf-billing-monitor / HCReaderWorker と同じ pattern)。
-      deploy_staging_script: 'npx wrangler deploy --env staging'
+      # single-env 運用 (staging = prod): PR run の deploy-staging job と tag push の
+      # deploy-release job は共に root config (= 唯一の worker
+      # `security-notification-app`) を deploy する。cf-billing-monitor /
+      # HealthConnectReaderWorker と同じ pattern。
+      deploy_staging_script: 'npx wrangler deploy'
       deploy_release_script: 'npx wrangler deploy'
     secrets: inherit

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -59,43 +59,5 @@
 			"store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
 			"secret_name": "security-notification-app-cf-api-token"
 		}
-	],
-	"env": {
-		"staging": {
-			"name": "security-notification-app-staging",
-			"durable_objects": {
-				"bindings": [
-					{
-						"class_name": "NotificationManager",
-						"name": "NOTIFICATION_MANAGER"
-					}
-				]
-			},
-			"kv_namespaces": [
-				{
-					"binding": "PROCESSED_EVENTS",
-					"id": "78e463be2e6846d68afcde0fe204ccdf",
-					"preview_id": "78e463be2e6846d68afcde0fe204ccdf"
-				}
-			],
-			"send_email": [
-				{
-					"name": "EMAIL",
-					"destination_address": "m.tama.ramu@gmail.com"
-				}
-			],
-			"vars": {
-				"CLOUDFLARE_ZONE_IDS": "2eb0f540aaf601916d2749c88ad005aa,f95be7b0a4ca5b49ed6ca5dd448511b0",
-				"NOTIFY_EMAIL_FROM": "security-alert@mtamaramu.com",
-				"NOTIFY_EMAIL_TO": "m.tama.ramu@gmail.com"
-			},
-			"secrets_store_secrets": [
-				{
-					"binding": "CLOUDFLARE_API_TOKEN",
-					"store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
-					"secret_name": "security-notification-app-cf-api-token"
-				}
-			]
-		}
-	}
+	]
 }


### PR DESCRIPTION
## Summary

user 指示「staging = prod 運用にして」に従い、cf-billing-monitor / HealthConnectReaderWorker と同じ **single-env pattern** に揃える。

- `wrangler.jsonc` から `env.staging` block を削除 (root config 1 個のみ)
- `test.yml` の `deploy_staging_script` を `npx wrangler deploy` に変更 (= root config = 唯一の worker `security-notification-app` を deploy)

## 経緯

PR #12 で Secrets Store binding を入れて、PR #13 で deploy script を caller に追加。しかし `deploy-staging` job は **PR run 限定**、`deploy-release` は **tag push 限定** という frontend-ci.yml の設計。

PR #13 の PR run で `deploy_staging_script: 'npx wrangler deploy --env staging'` が動き、**staging worker** (`security-notification-app-staging`) は新コードで deploy されたが、**prod worker** (`security-notification-app`) はそのまま 400 fail し続けていた。

cf-billing-monitor の comment に明記:
> single-env: staging deploy と release deploy は同じ root config を叩く。main push (= PR merge) で本番反映、v* tag も同一 config を deploy する

これに揃えれば PR run で root config (= prod) が deploy されるので、merge を待たずに prod が更新される。

## merge 後の状態

| job | trigger | deploy 先 |
|---|---|---|
| `deploy-staging` | PR run (non-draft) | root = `security-notification-app` (= prod) |
| `deploy-release` | `v*` tag push | root = `security-notification-app` (= prod) |

PR run と tag push の両方で root config を deploy。

## 副作用 / 後片付け

PR #13 merge 時に CI が deploy した **orphan worker `security-notification-app-staging`** は今後 deploy されない。Cloudflare dashboard から手動 delete してよい (実害は無いが、Workers の Free plan worker 数を 1 食う + 同 KV / DO を共有しているため cron が二重発火している可能性あり)。

dashboard: https://dash.cloudflare.com/24b45709d060d957340180e995f0d373/workers/services/view/security-notification-app-staging → Settings → Delete

## Test plan

- [x] `npx tsc --noEmit` (clean)
- [x] `npm test` — 57/57 pass
- [ ] PR run の `Deploy Staging` job が **root config** を deploy することを確認 (= `wrangler deploy` の log で `Uploaded security-notification-app` と出る)
- [ ] deploy 完走後 5 分以内の cron で `cf_logging` の 400 error が消失することを確認

Refs #11

https://claude.ai/code/session_01RwZm9s4kqbHQZ12fc9LjhG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwZm9s4kqbHQZ12fc9LjhG)_