### PR TITLE
fix: rename clientCountry → clientCountryName in GraphQL query (Refs #11)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ export class NotificationManager extends DurableObject<Env> {
 						datetime
 						action
 						clientIP
-						clientCountry
+						clientCountryName
 						clientRequestHTTPMethodName
 						clientRequestHTTPHost
 						clientRequestPath
@@ -162,7 +162,7 @@ export class NotificationManager extends DurableObject<Env> {
 			timestamp: event.datetime,
 			action: event.action,
 			clientIP: event.clientIP,
-			country: event.clientCountry,
+			country: event.clientCountryName,
 			method: event.clientRequestHTTPMethodName,
 			host: event.clientRequestHTTPHost,
 			uri: event.clientRequestPath,

--- a/test/edge-cases.test.ts
+++ b/test/edge-cases.test.ts
@@ -407,13 +407,13 @@ describe('Edge Cases and Error Handling', () => {
 							zones: [
 								{ firewallEventsAdaptive: [{
 									rayName: 'zone1-event', datetime: new Date().toISOString(),
-									action: 'block', clientIP: '1.1.1.1', clientCountry: 'US',
+									action: 'block', clientIP: '1.1.1.1', clientCountryName: 'US',
 									clientRequestHTTPMethodName: 'GET', clientRequestHTTPHost: 'a.example.com',
 									clientRequestPath: '/', userAgent: 'UA', ruleId: 'r1', description: 'd1',
 								}] },
 								{ firewallEventsAdaptive: [{
 									rayName: 'zone2-event', datetime: new Date().toISOString(),
-									action: 'challenge', clientIP: '2.2.2.2', clientCountry: 'JP',
+									action: 'challenge', clientIP: '2.2.2.2', clientCountryName: 'JP',
 									clientRequestHTTPMethodName: 'POST', clientRequestHTTPHost: 'b.example.com',
 									clientRequestPath: '/x', userAgent: 'UA', ruleId: 'r2', description: 'd2',
 								}] },

--- a/test/helpers/test-helpers.ts
+++ b/test/helpers/test-helpers.ts
@@ -36,7 +36,7 @@ export function createGraphQLSecurityResponse(events: any[]) {
 						datetime: e.occurred_at ?? e.datetime ?? new Date().toISOString(),
 						action: e.action ?? 'block',
 						clientIP: e.client_ip ?? e.clientIP ?? '1.2.3.4',
-						clientCountry: e.country ?? e.clientCountry ?? 'US',
+						clientCountryName: e.country ?? e.clientCountryName ?? e.clientCountry ?? 'US',
 						clientRequestHTTPMethodName: e.method ?? e.clientRequestHTTPMethodName ?? 'GET',
 						clientRequestHTTPHost: e.host ?? e.clientRequestHTTPHost ?? 'example.com',
 						clientRequestPath: e.uri ?? e.clientRequestPath ?? '/test',


### PR DESCRIPTION
## Summary

PR #14 merge 後 prod に新コードが deploy され (`scriptVersion 4fc54830`)、Bearer 認証は通るようになったが、07:05 UTC cron で**別の error** が出現:

```
GraphQL error: unknown field "clientCountry"
```

Cloudflare GraphQL Analytics API の `firewallEventsAdaptive` は **`clientCountryName`** を要求しているのに、元 src/index.ts は **`clientCountry`** を query していた。

これは元から存在した typo。旧 400 (Bearer empty) の影で長らく検出されなかった (= サーバ側が field 名 validation より先に auth で reject していたため)。

## 修正

- `src/index.ts` の GraphQL query field 名と mapper の `event.clientCountry` → `event.clientCountryName`
- test fixtures (`test-helpers.ts` の `createGraphQLSecurityResponse` と `edge-cases.test.ts` の multi-zone mock) も `clientCountryName` に揃える

## Test plan

- [x] `npx tsc --noEmit` (clean)
- [x] `npm test` — 57/57 pass
- [ ] merge + PR run の Deploy Staging で prod 更新後、次の cron で error 消失 + (firewall events があれば) email 到着

Refs #11

https://claude.ai/code/session_01RwZm9s4kqbHQZ12fc9LjhG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwZm9s4kqbHQZ12fc9LjhG)_