### PR TITLE
feat: log detected security events to Workers Observability (Refs #11)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,8 +83,26 @@ export class NotificationManager extends DurableObject<Env> {
 			
 			// Send all unprocessed events in a single batch
 			if (unprocessedEvents.length > 0) {
+				// 構造化 log: Workers Observability から `event:` フィルタで
+				// query 可能。email を開かなくても CCoW セッションから
+				// `cf_logging` MCP で attacker IP / rule 等を確認できる。
+				console.log('security_events_detected', JSON.stringify({
+					count: unprocessedEvents.length,
+					events: unprocessedEvents.map((e) => ({
+						id: e.id,
+						timestamp: e.timestamp,
+						action: e.action,
+						clientIP: e.clientIP,
+						country: e.country,
+						method: e.method,
+						host: e.host,
+						uri: e.uri,
+						ruleName: e.ruleName,
+					})),
+				}));
+
 				await this.sendNotificationsBatch(unprocessedEvents);
-				
+
 				// Mark all events as processed
 				for (const event of unprocessedEvents) {
 					const eventKey = `event:${event.id}`;


### PR DESCRIPTION
## Summary

user 指示「log に残せば CCoW からも確認できるだろ」に対応。

email は届くが、CCoW セッションから過去 event を確認したい時に Gmail を開かないと内容が見えないのが不便。Workers Observability に構造化 log を残せば `cf_logging` MCP で query 可能になる。

## 変更

`src/index.ts` の `checkAndNotifySecurityEvents` で、未処理 events を `sendNotificationsBatch` 直前で `console.log('security_events_detected', JSON.stringify({...}))` として出力。

KV mark (24h dedupe) の **前** に log するので、重複 event は log にも乗らない (= email と同じ「新規 events のみ」が log に出る)。

## 確認方法 (merge / deploy 後)

```
cf_logging MCP の query_worker_observability で:
  $metadata.service = security-notification-app
  $metadata.message contains "security_events_detected"
```

返ってきた JSON body に events 配列 (id / action / clientIP / country / method / host / uri / ruleName) が乗る。

## Test plan

- [x] `npx tsc --noEmit` (clean)
- [x] `npm test` — 57/57 pass
- [ ] merge → PR run の Deploy Staging で root config deploy
- [ ] 次の cron tick (または手動 trigger) で events 検出時に `security_events_detected` log が出力されることを確認

Refs #11

https://claude.ai/code/session_01RwZm9s4kqbHQZ12fc9LjhG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwZm9s4kqbHQZ12fc9LjhG)_