### PR TITLE
fix: render email/Slack timestamps in JST instead of Worker UTC default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -305,7 +305,7 @@ export class NotificationManager extends DurableObject<Env> {
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: `*Summary:* ${summaryText}\n*Time Range:* ${new Date(events[0].timestamp).toLocaleString()} - ${new Date(events[events.length - 1].timestamp).toLocaleString()}`
+					text: `*Summary:* ${summaryText}\n*Time Range (JST):* ${formatJst(events[0].timestamp)} - ${formatJst(events[events.length - 1].timestamp)}`
 				}
 			}
 		];
@@ -326,7 +326,7 @@ export class NotificationManager extends DurableObject<Env> {
 					{ type: 'mrkdwn', text: `*Host:* ${event.host}` },
 					{ type: 'mrkdwn', text: `*URI:* ${event.uri}` },
 					{ type: 'mrkdwn', text: `*Rule:* ${event.ruleName}` },
-					{ type: 'mrkdwn', text: `*Time:* ${new Date(event.timestamp).toLocaleString()}` }
+					{ type: 'mrkdwn', text: `*Time (JST):* ${formatJst(event.timestamp)}` }
 				]
 			});
 		});
@@ -373,7 +373,7 @@ export class NotificationManager extends DurableObject<Env> {
 
 		const rows = events.slice(0, 20).map(e => `
 			<tr>
-				<td>${escapeHtml(new Date(e.timestamp).toLocaleString())}</td>
+				<td>${escapeHtml(formatJst(e.timestamp))}</td>
 				<td>${escapeHtml(e.action)}</td>
 				<td>${escapeHtml(e.clientIP)}</td>
 				<td>${escapeHtml(e.country)}</td>
@@ -389,9 +389,9 @@ export class NotificationManager extends DurableObject<Env> {
 <html><body style="font-family: sans-serif;">
 <h2>🚨 ${events.length} Cloudflare Security Events</h2>
 <p><b>Summary:</b> ${escapeHtml(summaryText)}</p>
-<p><b>Time range:</b> ${escapeHtml(new Date(events[events.length - 1].timestamp).toLocaleString())} - ${escapeHtml(new Date(events[0].timestamp).toLocaleString())}</p>
+<p><b>Time range (JST):</b> ${escapeHtml(formatJst(events[events.length - 1].timestamp))} - ${escapeHtml(formatJst(events[0].timestamp))}</p>
 <table border="1" cellpadding="4" cellspacing="0" style="border-collapse: collapse;">
-	<thead><tr><th>Time</th><th>Action</th><th>Client IP</th><th>Country</th><th>Method</th><th>Host/URI</th><th>Rule</th></tr></thead>
+	<thead><tr><th>Time (JST)</th><th>Action</th><th>Client IP</th><th>Country</th><th>Method</th><th>Host/URI</th><th>Rule</th></tr></thead>
 	<tbody>${rows}</tbody>
 </table>
 ${moreNote}
@@ -589,4 +589,18 @@ function escapeHtml(s: string): string {
 		.replace(/>/g, '&gt;')
 		.replace(/"/g, '&quot;')
 		.replace(/'/g, '&#39;');
+}
+
+// Workers default to UTC, so explicitly pin display to JST.
+function formatJst(iso: string): string {
+	return new Date(iso).toLocaleString('ja-JP', {
+		timeZone: 'Asia/Tokyo',
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit',
+		hour12: false,
+	});
 }


### PR DESCRIPTION
## Summary

Cloudflare Workers default `Date.prototype.toLocaleString()` to UTC, so the notification email rendered times like `6/15/2026, 7:21:43 AM` for events that actually happened at 16:21 JST. Pin all email/Slack timestamp rendering to `ja-JP` / `Asia/Tokyo` via a shared `formatJst()` helper, and label the columns `(JST)` so the timezone is unambiguous in the inbox.

Changes are display-only — DB/log/wire timestamps remain ISO/UTC.

- `sendEmailBatch`: table cells, `Time range`, column header
- `sendSlackBatch`: `Time Range`, per-event `*Time*`
- new `formatJst(iso)` helper at the bottom of `src/index.ts`

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 57/57 passed (existing tests don't assert timestamp format; email batch swallows the expected `cloudflare:email` miniflare error)
- [ ] Manual: next `*/5 * * * *` cron run produces an email where the `Time range (JST)` line and table column read in Asia/Tokyo (i.e. `2026/06/15 16:21:43`)

Refs #18

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqUyQei4pBr3UkodQ5JSi6)_