### PR TITLE
feat: classify events by CF Access need + notification threshold

### DIFF
--- a/.claude/skills/security-notification-app-map/SKILL.md
+++ b/.claude/skills/security-notification-app-map/SKILL.md
@@ -27,6 +27,7 @@ Slack endpoint へ通知する単一 Worker。
 | `SecurityNotificationWorker` (default export) | `WorkerEntrypoint`。RPC method (`checkSecurityEvents` / `addEndpoint` 等) + HTTP route (`/api/endpoints` CRUD / `/api/check-events`) + `scheduled` (cron) |
 | `sendEmailBatch` (DO 内) | `cloudflare:email` + `mimetext` で HTML テーブル形式 email を送信。`NOTIFY_EMAIL_FROM` → `NOTIFY_EMAIL_TO` 固定、events 最大 20 件 + summary |
 | `sendWebhookBatch` / `sendSlackBatch` | endpoint type 別の通知。webhook は JSON POST、Slack は Block Kit |
+| `classify.ts` (別ファイル, pure) | CF Access 観点で host を 4 分類 (`access-candidate` / `unknown` / `gated` / `public`) + 集計 + email/Slack/webhook 用 render helper。`summarize` / `classifyHost` / `parseClassifyConfig` / `parseMinEvents` を export。副作用なし = `test/classify.test.ts` で 100% カバー |
 
 ## entrypoint (`fetch` の HTTP route)
 
@@ -55,6 +56,7 @@ Slack endpoint へ通知する単一 Worker。
 - **GraphQL field 名は `clientCountryName`** (`clientCountry` ではない、PR #15 で 1 度踏んだ)。`firewallEventsAdaptive` の field 名は CF 側の schema 進化に追従が必要。
 - **48h KV dedupe**: 各 event の Ray ID を key にして `PROCESSED_EVENTS` KV に 48h TTL で書く (`event:<rayId>`)。fetch window が 24h なので TTL=48h で境界重複 (前日の cron で投げ損ねた event が翌日 window にもう一度入る等) を吸収する。`sendNotificationsBatch` の前に `console.log('security_events_detected', ...)` で構造化 log も出力 (PR #16) — CCoW から `cf_logging` MCP で過去 events を query 可能。
 - **email は常時送信**: PR #10 で `sendNotificationsBatch` 冒頭で `sendEmailBatch` を必ず呼ぶ。endpoint 登録不要 (endpoint type `email` は no-op)。webhook / Slack は endpoint 登録された分だけ追加で送る。
+- **CF Access 分類 + 件数閾値** (`src/classify.ts`): 通知に host の CF Access 対応要否分類 (⚠️要検討 / ❓不明 / ✅済 / 🌐公開) を載せ、email 件名に actionable 件数を付ける。host パターンは `ACCESS_{GATED,CANDIDATE,PUBLIC}_PATTERNS` env (未設定は ippoan default)。`NOTIFY_MIN_EVENTS` (default 1) 未満は通知抑制 (dedupe mark / log は残す)。分類は config ベースで live Access API は叩かない (token scope が Security Events Read のみのため = トリアージのヒント)。閾値分岐 (`this.env` scalar) は DO 実体の env に届けるため test では `runInDurableObject` で `(instance as any).env.NOTIFY_MIN_EVENTS` を直接 set する (test-side `env` proxy への代入は DO に伝播しない。KV binding は同一オブジェクト共有なので効く、の非対称に注意)。
 - **`send_email` binding** (`EMAIL`): `cloudflare:email` + `mimetext` で送信。`destination_address` は `wrangler.jsonc` の `[[send_email]]` で **静的固定** (Email Routing の制約)。From/To を変える時は `vars.NOTIFY_EMAIL_FROM` / `NOTIFY_EMAIL_TO` と `[[send_email]] destination_address` の **両方**を更新する必要あり。
 - **`cloudflare:email` は vitest-pool-workers v0.5 で module 解決失敗**: `sendEmailBatch` は dynamic import (`await import('cloudflare:email')`)。test では mock 不要 (path に到達しない or dynamic import が catch される)。
 - **PROD worker 名 `security-notification-app`**: workers.dev は `security-notification-app.m-tama-ramu.workers.dev`。CF dashboard では Variables and secrets に `Secrets Store / CLOUDFLARE_API_TOKEN` binding が出る (PR #12 以前は `Plaintext / CLOUDFLARE_API_TOKEN (空)` だった)。

--- a/README.md
+++ b/README.md
@@ -98,6 +98,46 @@ POST /api/check-events
 - `challenge`: チャレンジを受けたリクエスト
 - `jschallenge`: JavaScriptチャレンジ
 
+## CF Access 観点の分類 (トリアージ)
+
+通知 (email / Slack / webhook) には、各イベントの host を **CF Access 対応が必要か**で
+分類した集計が載る。`block` の大半は WAF が無料で弾いた routine だが、その中から
+「Access を被せるべき開発系」や「判断できない host」を拾い出すのが目的。
+
+| カテゴリ | 意味 |
+|---|---|
+| ⚠️ 要 CF Access 検討 | dev/staging/internal 風だが Access 未適用の host (= 対応候補) |
+| ❓ 不明 (要確認) | どのパターンにも当てはまらない host (= 人間が分類する対象) |
+| ✅ CF Access 済み | 既に Access で保護済みとみなす host |
+| 🌐 公開 (Access 不要) | 公開本番。WAF/Bot で対処 |
+
+- email 件名には actionable (要検討 + 不明) 件数が ` ⚠️要対応 N` として付く。
+- 分類ロジックは `src/classify.ts` (pure module、副作用なし)。host パターンは
+  `wrangler.jsonc` の `vars` で上書き可能 (未設定は ippoan 向けデフォルト):
+
+| var | デフォルト | 用途 |
+|---|---|---|
+| `ACCESS_GATED_PATTERNS` | `*-staging.ippoan.org,*-dev.ippoan.org` | Access 済み host |
+| `ACCESS_CANDIDATE_PATTERNS` | `*staging*,*dev*,*test*,*internal*,*admin*,*preview*` | 要対応候補 |
+| `ACCESS_PUBLIC_PATTERNS` | `*.ippoan.org,*.mtamaramu.com,*.m-tama-ramu.workers.dev` | 公開本番 |
+
+> 注: gated 判定は **config (host パターン) ベース**で、live な CF Access API は
+> 叩かない (worker token は Security Events Read scope のみ)。config に無い既 gated
+> host は candidate/public に誤分類され得る = あくまでトリアージのヒント。
+
+## 通知ノイズの抑制 (件数閾値)
+
+`NOTIFY_MIN_EVENTS` (plain var、未設定 = `1` で現状維持) を超えた時だけ通知する。
+少件数の routine block 日を黙らせたい場合に上げる。閾値未満でも **dedupe mark
+(`PROCESSED_EVENTS` KV) と observability log は残す**ので、取りこぼしや二重通知は無い。
+
+```jsonc
+// wrangler.jsonc vars 例
+"NOTIFY_MIN_EVENTS": "20"   // 20 件未満の日はメールしない
+```
+
+週次ダイジェストにしたい場合は `triggers.crons` を `"0 21 * * 0"` (日曜のみ) 等に変更する。
+
 ## 必要なCloudflare API権限
 
 APIトークンには以下の権限が必要です:

--- a/src/classify.ts
+++ b/src/classify.ts
@@ -1,0 +1,171 @@
+// CF Access 観点で WAF firewall event の host を分類する pure module。
+//
+// index.ts (Worker / Durable Object) から import して通知に
+// 「この host は CF Access 対応が必要か / 不明か」のトリアージ情報を載せる。
+// すべて副作用なし = vitest で全分岐を網羅テストする (coverage 100% gate)。
+//
+// 注意: 「gated (= 既に CF Access 済み)」判定は **config (host パターン)** ベース。
+// 本 module は live な CF Access API を叩かない (worker の token は Security
+// Events Read scope のみ)。よって config の gated パターンに載っていない
+// 既 gated host は `access-candidate` / `public` に誤分類され得る = あくまで
+// トリアージのヒント。正確な突合は将来 Access:read token + API 連携で拡張可能。
+
+export type AccessCategory = 'access-candidate' | 'unknown' | 'gated' | 'public';
+
+export interface ClassifyConfig {
+	/** 既に CF Access で保護済みとみなす host パターン。 */
+	gated: string[];
+	/** dev/staging/internal 風で「Access 対応を検討すべき」host パターン。 */
+	candidate: string[];
+	/** 公開本番で「Access 不要 (WAF/Bot で対処)」とみなす host パターン。 */
+	public: string[];
+}
+
+export interface ClassifyEnv {
+	ACCESS_GATED_PATTERNS?: string;
+	ACCESS_CANDIDATE_PATTERNS?: string;
+	ACCESS_PUBLIC_PATTERNS?: string;
+	NOTIFY_MIN_EVENTS?: string;
+}
+
+// ippoan のデフォルト。staging/dev custom domain は CF Access 済み
+// (security-notification-app 起点の Access 整備で `*-staging.ippoan.org` /
+// `*-dev.ippoan.org` を gate 済み)。env で上書き可能。
+export const DEFAULT_CLASSIFY_CONFIG: ClassifyConfig = {
+	gated: ['*-staging.ippoan.org', '*-dev.ippoan.org'],
+	candidate: ['*staging*', '*dev*', '*test*', '*internal*', '*admin*', '*preview*'],
+	public: ['*.ippoan.org', '*.mtamaramu.com', '*.m-tama-ramu.workers.dev'],
+};
+
+// 表示順 = トリアージ優先度 (要対応 → 不明 → 済 → 公開)。
+export const CATEGORY_ORDER: AccessCategory[] = ['access-candidate', 'unknown', 'gated', 'public'];
+
+export const CATEGORY_LABEL: Record<AccessCategory, string> = {
+	'access-candidate': '⚠️ 要 CF Access 検討',
+	unknown: '❓ 不明 (要確認)',
+	gated: '✅ CF Access 済み',
+	public: '🌐 公開 (Access 不要)',
+};
+
+const MAX_HOSTS_PER_BUCKET = 5;
+
+/** glob 風 (`*` = 任意文字列) パターンで host を完全一致判定する。case-insensitive。 */
+export function matchHostPattern(host: string, pattern: string): boolean {
+	const escaped = pattern
+		.toLowerCase()
+		.replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+		.replace(/\*/g, '.*');
+	return new RegExp(`^${escaped}$`).test(host.toLowerCase());
+}
+
+function matchesAny(host: string, patterns: string[]): boolean {
+	return patterns.some((p) => matchHostPattern(host, p));
+}
+
+/** host を CF Access 観点の 4 カテゴリに分類する (gated を最優先で判定)。 */
+export function classifyHost(host: string, cfg: ClassifyConfig = DEFAULT_CLASSIFY_CONFIG): AccessCategory {
+	if (matchesAny(host, cfg.gated)) return 'gated';
+	if (matchesAny(host, cfg.candidate)) return 'access-candidate';
+	if (matchesAny(host, cfg.public)) return 'public';
+	return 'unknown';
+}
+
+function splitCsv(v?: string): string[] | undefined {
+	if (!v) return undefined;
+	const arr = v
+		.split(',')
+		.map((s) => s.trim())
+		.filter(Boolean);
+	return arr.length > 0 ? arr : undefined;
+}
+
+/** env の comma-separated パターンを読む。未設定はデフォルトに fallback。 */
+export function parseClassifyConfig(env: ClassifyEnv): ClassifyConfig {
+	return {
+		gated: splitCsv(env.ACCESS_GATED_PATTERNS) ?? DEFAULT_CLASSIFY_CONFIG.gated,
+		candidate: splitCsv(env.ACCESS_CANDIDATE_PATTERNS) ?? DEFAULT_CLASSIFY_CONFIG.candidate,
+		public: splitCsv(env.ACCESS_PUBLIC_PATTERNS) ?? DEFAULT_CLASSIFY_CONFIG.public,
+	};
+}
+
+/** 通知の件数閾値。未設定・不正・0 以下は 1 (= 現状維持: 1 件でも通知)。 */
+export function parseMinEvents(env: ClassifyEnv): number {
+	const n = env.NOTIFY_MIN_EVENTS ? parseInt(env.NOTIFY_MIN_EVENTS, 10) : NaN;
+	return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+export interface CategoryBucket {
+	category: AccessCategory;
+	count: number;
+	hosts: Array<{ host: string; count: number }>;
+}
+
+export interface ClassifiedSummary {
+	total: number;
+	/** access-candidate + unknown = 人間のトリアージが要る件数。 */
+	actionableCount: number;
+	/** CATEGORY_ORDER 順、count>0 の bucket のみ。 */
+	buckets: CategoryBucket[];
+}
+
+/** events を host 分類で集計する。 */
+export function summarize(
+	events: Array<{ host: string }>,
+	cfg: ClassifyConfig = DEFAULT_CLASSIFY_CONFIG,
+): ClassifiedSummary {
+	const perCategory: Record<AccessCategory, Map<string, number>> = {
+		'access-candidate': new Map(),
+		unknown: new Map(),
+		gated: new Map(),
+		public: new Map(),
+	};
+	for (const e of events) {
+		const m = perCategory[classifyHost(e.host, cfg)];
+		m.set(e.host, (m.get(e.host) ?? 0) + 1);
+	}
+
+	const buckets: CategoryBucket[] = [];
+	let actionableCount = 0;
+	for (const category of CATEGORY_ORDER) {
+		const m = perCategory[category];
+		if (m.size === 0) continue;
+		const hosts = Array.from(m, ([host, count]) => ({ host, count })).sort((a, b) => b.count - a.count);
+		const count = hosts.reduce((sum, h) => sum + h.count, 0);
+		buckets.push({ category, count, hosts });
+		if (category === 'access-candidate' || category === 'unknown') actionableCount += count;
+	}
+	return { total: events.length, actionableCount, buckets };
+}
+
+function hostsLine(bucket: CategoryBucket): string {
+	const shown = bucket.hosts
+		.slice(0, MAX_HOSTS_PER_BUCKET)
+		.map((h) => `${h.host} (${h.count})`)
+		.join(', ');
+	const extra = bucket.hosts.length - MAX_HOSTS_PER_BUCKET;
+	return extra > 0 ? `${shown}, +${extra} hosts` : shown;
+}
+
+/** email/Slack の件名末尾に付ける「要対応 N」。0 件なら空文字。 */
+export function classificationSubjectSuffix(summary: ClassifiedSummary): string {
+	return summary.actionableCount > 0 ? ` ⚠️要対応 ${summary.actionableCount}` : '';
+}
+
+/** プレーンテキスト行 (各 bucket 1 行)。 */
+export function renderClassificationLines(summary: ClassifiedSummary): string[] {
+	return summary.buckets.map((b) => `${CATEGORY_LABEL[b.category]}: ${b.count} — ${hostsLine(b)}`);
+}
+
+/** Slack mrkdwn (bullet)。bucket 0 件なら "分類対象なし"。 */
+export function renderClassificationMrkdwn(summary: ClassifiedSummary): string {
+	const lines = renderClassificationLines(summary);
+	return lines.length > 0 ? lines.map((l) => `• ${l}`).join('\n') : '分類対象なし';
+}
+
+/** email HTML。escape は呼び出し側の escapeHtml を注入。 */
+export function renderClassificationHtml(summary: ClassifiedSummary, escape: (s: string) => string): string {
+	const items = summary.buckets
+		.map((b) => `<li>${escape(CATEGORY_LABEL[b.category])}: <b>${b.count}</b> — ${escape(hostsLine(b))}</li>`)
+		.join('');
+	return `<h3>CF Access 観点の分類</h3><ul>${items}</ul>`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,13 @@
 import { DurableObject, WorkerEntrypoint, RpcTarget } from "cloudflare:workers";
+import {
+	parseClassifyConfig,
+	parseMinEvents,
+	summarize,
+	classificationSubjectSuffix,
+	renderClassificationHtml,
+	renderClassificationMrkdwn,
+	type ClassifyEnv,
+} from "./classify";
 
 // CF Secrets Store binding (`secrets_store_secrets`) is exposed in production
 // as an object with async `.get()`. In vitest (miniflare lacks a Secrets Store
@@ -83,11 +92,16 @@ export class NotificationManager extends DurableObject<Env> {
 			
 			// Send all unprocessed events in a single batch
 			if (unprocessedEvents.length > 0) {
+				const cfg = parseClassifyConfig(this.env as unknown as ClassifyEnv);
+				const summary = summarize(unprocessedEvents, cfg);
+
 				// 構造化 log: Workers Observability から `event:` フィルタで
 				// query 可能。email を開かなくても CCoW セッションから
-				// `cf_logging` MCP で attacker IP / rule 等を確認できる。
+				// `cf_logging` MCP で attacker IP / rule / CF Access 分類を確認できる。
 				console.log('security_events_detected', JSON.stringify({
 					count: unprocessedEvents.length,
+					actionable: summary.actionableCount,
+					categories: summary.buckets.map((b) => ({ category: b.category, count: b.count })),
 					events: unprocessedEvents.map((e) => ({
 						id: e.id,
 						timestamp: e.timestamp,
@@ -101,7 +115,12 @@ export class NotificationManager extends DurableObject<Env> {
 					})),
 				}));
 
-				await this.sendNotificationsBatch(unprocessedEvents);
+				// 件数閾値: 新規 event が NOTIFY_MIN_EVENTS 未満なら通知を抑制
+				// (observability log は残す)。既定 1 = 現状維持。dedupe のため
+				// 通知有無に関わらず processed mark は付ける。
+				if (unprocessedEvents.length >= parseMinEvents(this.env as unknown as ClassifyEnv)) {
+					await this.sendNotificationsBatch(unprocessedEvents);
+				}
 
 				// Mark all events as processed
 				for (const event of unprocessedEvents) {
@@ -267,6 +286,7 @@ export class NotificationManager extends DurableObject<Env> {
 	// }
 
 	private async sendWebhookBatch(url: string, events: SecurityEvent[]): Promise<void> {
+		const summary = summarize(events, parseClassifyConfig(this.env as unknown as ClassifyEnv));
 		const response = await fetch(url, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
@@ -274,6 +294,10 @@ export class NotificationManager extends DurableObject<Env> {
 				type: 'cloudflare_security_events_batch',
 				events: events,
 				count: events.length,
+				classification: {
+					actionable: summary.actionableCount,
+					categories: summary.buckets,
+				},
 				timestamp: new Date().toISOString()
 			})
 		});
@@ -293,6 +317,8 @@ export class NotificationManager extends DurableObject<Env> {
 			.map(([action, count]) => `${action.toUpperCase()}: ${count}`)
 			.join(', ');
 
+		const summary = summarize(events, parseClassifyConfig(this.env as unknown as ClassifyEnv));
+
 		const blocks: any[] = [
 			{
 				type: 'header',
@@ -306,6 +332,13 @@ export class NotificationManager extends DurableObject<Env> {
 				text: {
 					type: 'mrkdwn',
 					text: `*Summary:* ${summaryText}\n*Time Range (JST):* ${formatJst(events[0].timestamp)} - ${formatJst(events[events.length - 1].timestamp)}`
+				}
+			},
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `*CF Access 分類:*\n${renderClassificationMrkdwn(summary)}`
 				}
 			}
 		];
@@ -369,7 +402,8 @@ export class NotificationManager extends DurableObject<Env> {
 			.map(([action, count]) => `${action.toUpperCase()}: ${count}`)
 			.join(', ');
 
-		const subject = `[CF Security] ${events.length} events detected (${summaryText})`;
+		const summary = summarize(events, parseClassifyConfig(this.env as unknown as ClassifyEnv));
+		const subject = `[CF Security] ${events.length} events detected (${summaryText})${classificationSubjectSuffix(summary)}`;
 
 		const rows = events.slice(0, 20).map(e => `
 			<tr>
@@ -390,6 +424,7 @@ export class NotificationManager extends DurableObject<Env> {
 <h2>🚨 ${events.length} Cloudflare Security Events</h2>
 <p><b>Summary:</b> ${escapeHtml(summaryText)}</p>
 <p><b>Time range (JST):</b> ${escapeHtml(formatJst(events[events.length - 1].timestamp))} - ${escapeHtml(formatJst(events[0].timestamp))}</p>
+${renderClassificationHtml(summary, escapeHtml)}
 <table border="1" cellpadding="4" cellspacing="0" style="border-collapse: collapse;">
 	<thead><tr><th>Time (JST)</th><th>Action</th><th>Client IP</th><th>Country</th><th>Method</th><th>Host/URI</th><th>Rule</th></tr></thead>
 	<tbody>${rows}</tbody>

--- a/test/classify.test.ts
+++ b/test/classify.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import {
+	matchHostPattern,
+	classifyHost,
+	parseClassifyConfig,
+	parseMinEvents,
+	summarize,
+	classificationSubjectSuffix,
+	renderClassificationLines,
+	renderClassificationMrkdwn,
+	renderClassificationHtml,
+	DEFAULT_CLASSIFY_CONFIG,
+	type ClassifyConfig,
+} from '../src/classify';
+
+describe('matchHostPattern', () => {
+	it('matches a leading wildcard', () => {
+		expect(matchHostPattern('alc-staging.ippoan.org', '*-staging.ippoan.org')).toBe(true);
+	});
+	it('matches a substring wildcard', () => {
+		expect(matchHostPattern('foo-staging-bar.example', '*staging*')).toBe(true);
+	});
+	it('treats dots literally (no false wildcard match)', () => {
+		// `.` must not act as regex "any char": `aXippoan.org` must NOT match `*.ippoan.org`
+		expect(matchHostPattern('aXippoanXorg', '*.ippoan.org')).toBe(false);
+		expect(matchHostPattern('a.ippoan.org', '*.ippoan.org')).toBe(true);
+	});
+	it('is case-insensitive', () => {
+		expect(matchHostPattern('ALC-STAGING.IPPOAN.ORG', '*-staging.ippoan.org')).toBe(true);
+	});
+	it('matches an exact pattern and rejects non-matches', () => {
+		expect(matchHostPattern('exact.example.com', 'exact.example.com')).toBe(true);
+		expect(matchHostPattern('other.example.com', 'exact.example.com')).toBe(false);
+	});
+});
+
+describe('classifyHost', () => {
+	it('classifies gated hosts (highest precedence)', () => {
+		// staging matches gated, candidate(*staging*) and public(*.ippoan.org) too — gated wins
+		expect(classifyHost('alc-staging.ippoan.org')).toBe('gated');
+	});
+	it('classifies access-candidate (dev/staging-like, not gated)', () => {
+		expect(classifyHost('foo-staging.example.com')).toBe('access-candidate');
+		expect(classifyHost('admin.example.com')).toBe('access-candidate');
+	});
+	it('classifies public production hosts', () => {
+		expect(classifyHost('alc.ippoan.org')).toBe('public');
+		expect(classifyHost('rust-ichiban.mtamaramu.com')).toBe('public');
+	});
+	it('classifies unknown hosts', () => {
+		expect(classifyHost('scanner.evil.ru')).toBe('unknown');
+	});
+	it('honours a custom config', () => {
+		const cfg: ClassifyConfig = { gated: ['gated.x'], candidate: ['cand.x'], public: ['pub.x'] };
+		expect(classifyHost('gated.x', cfg)).toBe('gated');
+		expect(classifyHost('cand.x', cfg)).toBe('access-candidate');
+		expect(classifyHost('pub.x', cfg)).toBe('public');
+		expect(classifyHost('nope.x', cfg)).toBe('unknown');
+	});
+});
+
+describe('parseClassifyConfig', () => {
+	it('falls back to defaults when env is empty', () => {
+		expect(parseClassifyConfig({})).toEqual(DEFAULT_CLASSIFY_CONFIG);
+	});
+	it('overrides from comma-separated env vars', () => {
+		const cfg = parseClassifyConfig({
+			ACCESS_GATED_PATTERNS: 'a.com, b.com',
+			ACCESS_CANDIDATE_PATTERNS: '*stg*',
+			ACCESS_PUBLIC_PATTERNS: '*.pub.com',
+		});
+		expect(cfg.gated).toEqual(['a.com', 'b.com']);
+		expect(cfg.candidate).toEqual(['*stg*']);
+		expect(cfg.public).toEqual(['*.pub.com']);
+	});
+	it('treats whitespace-only env as unset (falls back)', () => {
+		const cfg = parseClassifyConfig({ ACCESS_GATED_PATTERNS: '  ,  ' });
+		expect(cfg.gated).toEqual(DEFAULT_CLASSIFY_CONFIG.gated);
+	});
+});
+
+describe('parseMinEvents', () => {
+	it('defaults to 1 when unset', () => {
+		expect(parseMinEvents({})).toBe(1);
+	});
+	it('parses a positive integer', () => {
+		expect(parseMinEvents({ NOTIFY_MIN_EVENTS: '5' })).toBe(5);
+	});
+	it('falls back to 1 for non-numeric values', () => {
+		expect(parseMinEvents({ NOTIFY_MIN_EVENTS: 'abc' })).toBe(1);
+	});
+	it('falls back to 1 for zero / negative', () => {
+		expect(parseMinEvents({ NOTIFY_MIN_EVENTS: '0' })).toBe(1);
+		expect(parseMinEvents({ NOTIFY_MIN_EVENTS: '-3' })).toBe(1);
+	});
+});
+
+describe('summarize', () => {
+	it('returns an empty summary for no events', () => {
+		const s = summarize([]);
+		expect(s.total).toBe(0);
+		expect(s.actionableCount).toBe(0);
+		expect(s.buckets).toEqual([]);
+	});
+
+	it('aggregates by category and host, counting duplicates', () => {
+		const events = [
+			{ host: 'alc-staging.ippoan.org' }, // gated
+			{ host: 'alc-staging.ippoan.org' }, // gated (duplicate host -> existing-count path)
+			{ host: 'foo-staging.example.com' }, // access-candidate
+			{ host: 'alc.ippoan.org' }, // public
+			{ host: 'scanner.evil.ru' }, // unknown
+		];
+		const s = summarize(events);
+		expect(s.total).toBe(5);
+		// actionable = candidate(1) + unknown(1)
+		expect(s.actionableCount).toBe(2);
+
+		const byCat = Object.fromEntries(s.buckets.map((b) => [b.category, b]));
+		expect(byCat['gated'].count).toBe(2);
+		expect(byCat['gated'].hosts).toEqual([{ host: 'alc-staging.ippoan.org', count: 2 }]);
+		expect(byCat['access-candidate'].count).toBe(1);
+		expect(byCat['public'].count).toBe(1);
+		expect(byCat['unknown'].count).toBe(1);
+
+		// buckets are ordered: candidate -> unknown -> gated -> public
+		expect(s.buckets.map((b) => b.category)).toEqual(['access-candidate', 'unknown', 'gated', 'public']);
+	});
+
+	it('sorts hosts within a bucket by count desc', () => {
+		const events = [
+			{ host: 'a.evil.ru' },
+			{ host: 'b.evil.ru' },
+			{ host: 'b.evil.ru' },
+		];
+		const s = summarize(events);
+		const unknown = s.buckets.find((b) => b.category === 'unknown')!;
+		expect(unknown.hosts[0]).toEqual({ host: 'b.evil.ru', count: 2 });
+		expect(unknown.hosts[1]).toEqual({ host: 'a.evil.ru', count: 1 });
+	});
+});
+
+describe('rendering helpers', () => {
+	// 6 distinct unknown hosts -> exercises the "+N hosts" overflow branch (>5)
+	const manyUnknown = summarize(
+		['a', 'b', 'c', 'd', 'e', 'f'].map((p) => ({ host: `${p}.evil.ru` })),
+	);
+	// only gated -> actionable 0 (subject suffix empty branch)
+	const onlyGated = summarize([{ host: 'alc-staging.ippoan.org' }]);
+	const empty = summarize([]);
+
+	it('classificationSubjectSuffix shows actionable count, empty when none', () => {
+		expect(classificationSubjectSuffix(manyUnknown)).toBe(' ⚠️要対応 6');
+		expect(classificationSubjectSuffix(onlyGated)).toBe('');
+	});
+
+	it('renderClassificationLines truncates hosts past the cap', () => {
+		const lines = renderClassificationLines(manyUnknown);
+		expect(lines).toHaveLength(1);
+		expect(lines[0]).toContain('❓ 不明 (要確認): 6');
+		expect(lines[0]).toContain('+1 hosts'); // 6 hosts, cap 5
+	});
+
+	it('renderClassificationLines without overflow omits the "+N hosts" suffix', () => {
+		const lines = renderClassificationLines(onlyGated);
+		expect(lines[0]).toContain('✅ CF Access 済み: 1');
+		expect(lines[0]).not.toContain('+');
+	});
+
+	it('renderClassificationMrkdwn bullets lines, falls back when empty', () => {
+		expect(renderClassificationMrkdwn(onlyGated)).toContain('• ✅ CF Access 済み: 1');
+		expect(renderClassificationMrkdwn(empty)).toBe('分類対象なし');
+	});
+
+	it('renderClassificationHtml escapes labels/hosts via injected escaper', () => {
+		const calls: string[] = [];
+		const escape = (s: string) => {
+			calls.push(s);
+			return s.replace(/&/g, '&amp;');
+		};
+		const html = renderClassificationHtml(onlyGated, escape);
+		expect(html).toContain('<h3>CF Access 観点の分類</h3>');
+		expect(html).toContain('<b>1</b>');
+		expect(calls.length).toBeGreaterThan(0); // escaper was invoked
+	});
+});

--- a/test/durable-objects.test.ts
+++ b/test/durable-objects.test.ts
@@ -275,6 +275,56 @@ describe('Durable Objects', () => {
 	});
 
 	describe('Branch Coverage', () => {
+		it('should suppress notification below NOTIFY_MIN_EVENTS but still mark processed', async () => {
+			const id = testEnv.NOTIFICATION_MANAGER.idFromName('test-min-events');
+			const stub = testEnv.NOTIFICATION_MANAGER.get(id);
+			await stub.addEndpoint(createTestEndpoint({ enabled: true }));
+
+			let webhookCalled = false;
+			(global.fetch as any).mockImplementation((url: string) => {
+				if (url.includes('api.cloudflare.com')) {
+					return Promise.resolve(createGraphQLSecurityResponse([{
+						ray_id: 'below-threshold-1', action: 'block', client_ip: '9.9.9.9',
+						country: 'US', method: 'GET', host: 'example.com', uri: '/x',
+						user_agent: 'UA', rule_id: 'r', rule_message: 'Blocked'
+					}]));
+				}
+				if (url.includes('example.com')) {
+					webhookCalled = true;
+					return Promise.resolve(new Response('OK', { status: 200 }));
+				}
+				return Promise.resolve(new Response('Not Found', { status: 404 }));
+			});
+
+			const originalGet = testEnv.PROCESSED_EVENTS.get;
+			const originalPut = testEnv.PROCESSED_EVENTS.put;
+			testEnv.PROCESSED_EVENTS.get = vi.fn().mockResolvedValue(null);
+			testEnv.PROCESSED_EVENTS.put = vi.fn().mockResolvedValue(undefined);
+
+			// NOTIFY_MIN_EVENTS is a scalar var read from `this.env`; the DO env is a
+			// distinct object from the test-side `env`, so set it on the live instance.
+			await runInDurableObject(stub, async (instance: NotificationManager) => {
+				const doEnv = (instance as any).env;
+				doEnv.NOTIFY_MIN_EVENTS = '5';
+				try {
+					await instance.checkAndNotifySecurityEvents();
+
+					// 1 event < threshold 5 -> no notification sent, but dedupe mark still written
+					expect(webhookCalled).toBe(false);
+					expect(testEnv.PROCESSED_EVENTS.put).toHaveBeenCalledWith(
+						'event:below-threshold-1',
+						expect.any(String),
+						expect.objectContaining({ expirationTtl: 172800 })
+					);
+				} finally {
+					delete doEnv.NOTIFY_MIN_EVENTS;
+				}
+			});
+
+			testEnv.PROCESSED_EVENTS.get = originalGet;
+			testEnv.PROCESSED_EVENTS.put = originalPut;
+		});
+
 		it('should handle empty result array from API', async () => {
 			const id = testEnv.NOTIFICATION_MANAGER.idFromName('test-empty-result');
 			const stub = testEnv.NOTIFICATION_MANAGER.get(id);


### PR DESCRIPTION
## 背景

CF Security 通知 (134 件 BLOCK 等) を受けて、(1) 通知ノイズの抑制 と (2) **どの host が CF Access 対応が必要か / 不明か**でイベントを分類表示したい、という要望。

WAF block 自体は Worker 課金対象外だが、その中から「Access を被せるべき開発系」「判断できない host」を拾ってトリアージできるようにする。

## 変更内容

### 1. CF Access 観点の分類表示
email / Slack / webhook / 構造化 log に、host を 4 分類した集計を載せる:

| カテゴリ | 意味 |
|---|---|
| ⚠️ 要 CF Access 検討 | dev/staging/internal 風だが Access 未適用 (= 対応候補) |
| ❓ 不明 (要確認) | どのパターンにも該当しない (= 人間が分類する対象) |
| ✅ CF Access 済み | Access 済みとみなす host |
| 🌐 公開 (Access 不要) | 公開本番 (WAF/Bot で対処) |

- email 件名に actionable (要検討 + 不明) 件数を ` ⚠️要対応 N` で付与。
- 分類は pure module `src/classify.ts` (副作用なし、`test/classify.test.ts` で 100% カバー)。
- host パターンは `ACCESS_{GATED,CANDIDATE,PUBLIC}_PATTERNS` env で上書き可 (未設定は ippoan default)。
- **live な CF Access API は叩かない** (worker token は Security Events Read scope のみ) → config ベースのトリアージヒント。誤分類し得る点は README/SKILL に明記。

### 2. 通知ノイズ抑制 (件数閾値)
- `NOTIFY_MIN_EVENTS` (plain var、default `1` = 現状維持) 未満は通知抑制。
- 抑制時も **dedupe mark (KV) と observability log は残す**ので取りこぼし・二重通知なし。
- 週次化したい場合は `triggers.crons` を変更 (README に記載)。

## テスト

- `npx vitest run` → **83 passed**、`npx tsc --noEmit` OK。
- `src/classify.ts` は coverage **100%**。`src/index.ts` は 92.77% → **93.06%** (微増、未カバーは元々 miniflare で解決不可の `cloudflare:email` 送信本体 + GraphQL error throw で本 PR 起因ではない)。
- 閾値分岐は `runInDurableObject` で DO 実体 env に `NOTIFY_MIN_EVENTS` を注入してテスト (test-side `env` proxy への scalar 代入は DO に伝播しない非対称に対応)。

## 補足

本 PR は通知側のみ。先行して staging/dev custom domain (`*-staging.ippoan.org` 一括 + carve-out) には CF Access を適用済み (Cloudflare Access config、別作業)。

Refs #20


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3DCAqQFe1tjjpeQ3z4fHH)_