### PR TITLE
chore: classify *staging*.mtamaramu.com as CF Access gated

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -51,7 +51,10 @@
 	"vars": {
 		"CLOUDFLARE_ZONE_IDS": "2eb0f540aaf601916d2749c88ad005aa,f95be7b0a4ca5b49ed6ca5dd448511b0",
 		"NOTIFY_EMAIL_FROM": "security-alert@mtamaramu.com",
-		"NOTIFY_EMAIL_TO": "m.tama.ramu@gmail.com"
+		"NOTIFY_EMAIL_TO": "m.tama.ramu@gmail.com",
+		// CF Access 済みとみなす host (分類で ✅ 扱い)。default + mtamaramu staging 系
+		// (staging.hono-logi / staging-durable-object-test 等、CF Access 適用済み) を追加。
+		"ACCESS_GATED_PATTERNS": "*-staging.ippoan.org,*-dev.ippoan.org,*staging*.mtamaramu.com"
 	},
 	"secrets_store_secrets": [
 		{


### PR DESCRIPTION
## 背景

#21 で導入した CF Access 分類で、`staging.hono-logi.mtamaramu.com` と `staging-durable-object-test.mtamaramu.com` が ⚠️ access-candidate (要対応) として検出された。これらに CF Access (allow me) を適用済み (Cloudflare Access config) だが、分類器のデフォルト gated パターン (`*-staging.ippoan.org` / `*-dev.ippoan.org`) に一致せず、次回以降も ⚠️要対応 として出続けてしまう。

## 変更

`wrangler.jsonc` の `vars.ACCESS_GATED_PATTERNS` を明示設定し、`*staging*.mtamaramu.com` を gated に追加。これで mtamaramu の staging 系 host が ✅ CF Access 済み として分類され、誤検出ノイズが消える。

```
*-staging.ippoan.org,*-dev.ippoan.org,*staging*.mtamaramu.com
```

## テスト

- `npx tsc --noEmit` OK / `npx vitest run` **83 passed**。
- 分類ロジック (`src/classify.ts`) は env 上書きを既にサポート済みのため code 変更なし、設定のみ。

Refs #20


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3DCAqQFe1tjjpeQ3z4fHH)_