### PR TITLE
feat: ?force=1 on /api/check-events for manual test send

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,20 +71,22 @@ export class NotificationManager extends DurableObject<Env> {
 		}
 	}
 
-	async checkAndNotifySecurityEvents(): Promise<void> {
+	// force=true で dedupe (PROCESSED_EVENTS) と NOTIFY_MIN_EVENTS 閾値を無視し、
+	// 直近 24h の全 event を再通知する (手動テスト送信用、`/api/check-events?force=1`)。
+	async checkAndNotifySecurityEvents(force = false): Promise<void> {
 		try {
 			const now = new Date();
 			const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
 
 			const events = await this.fetchSecurityEvents(oneDayAgo, now);
-			
-			// Collect unprocessed events
+
+			// Collect unprocessed events (force=true は全件を対象にする)
 			const unprocessedEvents: SecurityEvent[] = [];
-			
+
 			for (const event of events) {
 				const eventKey = `event:${event.id}`;
-				const processed = await this.env.PROCESSED_EVENTS.get(eventKey);
-				
+				const processed = force ? null : await this.env.PROCESSED_EVENTS.get(eventKey);
+
 				if (!processed) {
 					unprocessedEvents.push(event);
 				}
@@ -118,7 +120,7 @@ export class NotificationManager extends DurableObject<Env> {
 				// 件数閾値: 新規 event が NOTIFY_MIN_EVENTS 未満なら通知を抑制
 				// (observability log は残す)。既定 1 = 現状維持。dedupe のため
 				// 通知有無に関わらず processed mark は付ける。
-				if (unprocessedEvents.length >= parseMinEvents(this.env as unknown as ClassifyEnv)) {
+				if (force || unprocessedEvents.length >= parseMinEvents(this.env as unknown as ClassifyEnv)) {
 					await this.sendNotificationsBatch(unprocessedEvents);
 				}
 
@@ -601,10 +603,13 @@ export default class SecurityNotificationWorker extends WorkerEntrypoint<Env> {
 			return Response.json({ success: true });
 		}
 
-		// Manual trigger for checking security events
+		// Manual trigger for checking security events.
+		// `?force=1` (or `?force=true`) で dedupe / 閾値を無視して直近 24h を再送 (テスト用)。
 		if (url.pathname === '/api/check-events' && request.method === 'POST') {
-			await notificationManager.checkAndNotifySecurityEvents();
-			return Response.json({ success: true, message: 'Security events checked' });
+			const forceParam = url.searchParams.get('force');
+			const force = forceParam === '1' || forceParam === 'true';
+			await notificationManager.checkAndNotifySecurityEvents(force);
+			return Response.json({ success: true, message: 'Security events checked', force });
 		}
 
 		return new Response('Security Notification API', { status: 200 });

--- a/test/api-endpoints.test.ts
+++ b/test/api-endpoints.test.ts
@@ -24,6 +24,18 @@ describe('API Endpoints', () => {
 			expect(data.success).toBe(true);
 			expect(data.message).toBe('Security events checked');
 		});
+
+		it('should accept force=1 and force=true on manual trigger', async () => {
+			mockFetch();
+			for (const v of ['1', 'true']) {
+				const response = await SELF.fetch(`http://localhost/api/check-events?force=${v}`, {
+					method: 'POST'
+				});
+				expect(response.status).toBe(200);
+				const data = await response.json() as { success: boolean; force: boolean };
+				expect(data.force).toBe(true);
+			}
+		});
 	});
 
 	describe('Endpoint Management', () => {

--- a/test/durable-objects.test.ts
+++ b/test/durable-objects.test.ts
@@ -325,6 +325,38 @@ describe('Durable Objects', () => {
 			testEnv.PROCESSED_EVENTS.put = originalPut;
 		});
 
+		it('should resend already-processed events when force=true', async () => {
+			const id = testEnv.NOTIFICATION_MANAGER.idFromName('test-force-resend');
+			const stub = testEnv.NOTIFICATION_MANAGER.get(id);
+			await stub.addEndpoint(createTestEndpoint({ enabled: true }));
+
+			let webhookCalled = false;
+			(global.fetch as any).mockImplementation((url: string) => {
+				if (url.includes('api.cloudflare.com')) {
+					return Promise.resolve(createGraphQLSecurityResponse([{
+						ray_id: 'force-ev-1', action: 'block', client_ip: '8.8.8.8',
+						country: 'US', method: 'GET', host: 'example.com', uri: '/f',
+						user_agent: 'UA', rule_id: 'r', rule_message: 'Blocked'
+					}]));
+				}
+				if (url.includes('example.com')) {
+					webhookCalled = true;
+					return Promise.resolve(new Response('OK', { status: 200 }));
+				}
+				return Promise.resolve(new Response('Not Found', { status: 404 }));
+			});
+
+			// KV reports the event as already processed; force must bypass dedupe + threshold
+			const originalGet = testEnv.PROCESSED_EVENTS.get;
+			testEnv.PROCESSED_EVENTS.get = vi.fn().mockResolvedValue('exists');
+
+			await stub.checkAndNotifySecurityEvents(true);
+
+			expect(webhookCalled).toBe(true);
+
+			testEnv.PROCESSED_EVENTS.get = originalGet;
+		});
+
 		it('should handle empty result array from API', async () => {
 			const id = testEnv.NOTIFICATION_MANAGER.idFromName('test-empty-result');
 			const stub = testEnv.NOTIFICATION_MANAGER.get(id);


### PR DESCRIPTION
## 背景

手動トリガー `/api/check-events` は dedupe (`PROCESSED_EVENTS` KV, 48h) で処理済みイベントを再送しないため、「直近のイベントは既に通知済みで新規ゼロ → 何も送られない」状態だと**通知の体裁（分類表示など）を手元で確認できない**。新しいイベントが来るまで待つしかなかった。

## 変更

`POST /api/check-events?force=1`（または `?force=true`）で **dedupe と `NOTIFY_MIN_EVENTS` 閾値を無視**し、直近 24h の全イベントを再通知する。テスト送信・体裁確認に使う。

- `force` 無し（既定）の挙動は不変。
- `checkAndNotifySecurityEvents(force = false)` に引数追加。`force` 時は KV get をスキップ（全件 unprocessed 扱い）＋ 閾値スキップ。processed mark は従来どおり付ける。
- response に `force` boolean を追加。

## テスト

- `npx tsc --noEmit` OK / `npx vitest run` **85 passed**（+2: force 再送 / route の force=1,true parse）。

Refs #20


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3DCAqQFe1tjjpeQ3z4fHH)_