### PR TITLE
chore: classify ui-preview.ippoan.org as CF Access gated

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -54,7 +54,7 @@
 		"NOTIFY_EMAIL_TO": "m.tama.ramu@gmail.com",
 		// CF Access 済みとみなす host (分類で ✅ 扱い)。default + mtamaramu staging 系
 		// (staging.hono-logi / staging-durable-object-test 等、CF Access 適用済み) を追加。
-		"ACCESS_GATED_PATTERNS": "*-staging.ippoan.org,*-dev.ippoan.org,*staging*.mtamaramu.com"
+		"ACCESS_GATED_PATTERNS": "*-staging.ippoan.org,*-dev.ippoan.org,*staging*.mtamaramu.com,ui-preview.ippoan.org"
 	},
 	"secrets_store_secrets": [
 		{


### PR DESCRIPTION
## 背景

force 送信 (180件) で ⚠️ access-candidate 4 件 = すべて `ui-preview.ippoan.org` と判明。これは分類器の `*preview*` ヒューリスティック誤検出で、実体はプレビュー配信サービス。`/`（デモ親ページ）のみ CF Access で gate し、`/p`（配信/publish/WS/stats）・`/mcp`・`/health` は bypass で公開、という path-limited gate を適用済み（Cloudflare Access config）。

## 変更

`ACCESS_GATED_PATTERNS` に `ui-preview.ippoan.org` を追加。`*preview*` candidate より gated 判定が優先されるため、次回以降の通知で ✅ CF Access 済み に分類され ⚠️要対応 から外れる。

```
*-staging.ippoan.org,*-dev.ippoan.org,*staging*.mtamaramu.com,ui-preview.ippoan.org
```

## テスト

`npx tsc --noEmit` OK / `npx vitest run` 85 passed（設定のみ、code 変更なし）。

Refs #20


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3DCAqQFe1tjjpeQ3z4fHH)_