### PR TITLE
feat: always show all 4 categories + per-host breakdown

### DIFF
--- a/src/classify.ts
+++ b/src/classify.ts
@@ -47,8 +47,6 @@ export const CATEGORY_LABEL: Record<AccessCategory, string> = {
 	public: '🌐 公開 (Access 不要)',
 };
 
-const MAX_HOSTS_PER_BUCKET = 5;
-
 /** glob 風 (`*` = 任意文字列) パターンで host を完全一致判定する。case-insensitive。 */
 export function matchHostPattern(host: string, pattern: string): boolean {
 	const escaped = pattern
@@ -124,26 +122,23 @@ export function summarize(
 		m.set(e.host, (m.get(e.host) ?? 0) + 1);
 	}
 
-	const buckets: CategoryBucket[] = [];
-	let actionableCount = 0;
-	for (const category of CATEGORY_ORDER) {
+	// 全 4 カテゴリを常に出す (count 0 の ⚠️要対応 / ❓不明 も通知に表示する)。
+	const buckets: CategoryBucket[] = CATEGORY_ORDER.map((category) => {
 		const m = perCategory[category];
-		if (m.size === 0) continue;
 		const hosts = Array.from(m, ([host, count]) => ({ host, count })).sort((a, b) => b.count - a.count);
 		const count = hosts.reduce((sum, h) => sum + h.count, 0);
-		buckets.push({ category, count, hosts });
-		if (category === 'access-candidate' || category === 'unknown') actionableCount += count;
-	}
+		return { category, count, hosts };
+	});
+	const actionableCount = buckets
+		.filter((b) => b.category === 'access-candidate' || b.category === 'unknown')
+		.reduce((sum, b) => sum + b.count, 0);
 	return { total: events.length, actionableCount, buckets };
 }
 
+// host 別の内訳 (全 host を細分表示、上限なし)。0 件カテゴリは "なし"。
 function hostsLine(bucket: CategoryBucket): string {
-	const shown = bucket.hosts
-		.slice(0, MAX_HOSTS_PER_BUCKET)
-		.map((h) => `${h.host} (${h.count})`)
-		.join(', ');
-	const extra = bucket.hosts.length - MAX_HOSTS_PER_BUCKET;
-	return extra > 0 ? `${shown}, +${extra} hosts` : shown;
+	if (bucket.hosts.length === 0) return 'なし';
+	return bucket.hosts.map((h) => `${h.host} (${h.count})`).join(', ');
 }
 
 /** email/Slack の件名末尾に付ける「要対応 N」。0 件なら空文字。 */
@@ -156,10 +151,9 @@ export function renderClassificationLines(summary: ClassifiedSummary): string[] 
 	return summary.buckets.map((b) => `${CATEGORY_LABEL[b.category]}: ${b.count} — ${hostsLine(b)}`);
 }
 
-/** Slack mrkdwn (bullet)。bucket 0 件なら "分類対象なし"。 */
+/** Slack mrkdwn (bullet)。全 4 カテゴリを 1 行ずつ。 */
 export function renderClassificationMrkdwn(summary: ClassifiedSummary): string {
-	const lines = renderClassificationLines(summary);
-	return lines.length > 0 ? lines.map((l) => `• ${l}`).join('\n') : '分類対象なし';
+	return renderClassificationLines(summary).map((l) => `• ${l}`).join('\n');
 }
 
 /** email HTML。escape は呼び出し側の escapeHtml を注入。 */

--- a/test/classify.test.ts
+++ b/test/classify.test.ts
@@ -96,11 +96,13 @@ describe('parseMinEvents', () => {
 });
 
 describe('summarize', () => {
-	it('returns an empty summary for no events', () => {
+	it('returns all 4 zero buckets for no events', () => {
 		const s = summarize([]);
 		expect(s.total).toBe(0);
 		expect(s.actionableCount).toBe(0);
-		expect(s.buckets).toEqual([]);
+		// all 4 categories always present (so ⚠️/❓ show even at 0)
+		expect(s.buckets.map((b) => b.category)).toEqual(['access-candidate', 'unknown', 'gated', 'public']);
+		expect(s.buckets.every((b) => b.count === 0 && b.hosts.length === 0)).toBe(true);
 	});
 
 	it('aggregates by category and host, counting duplicates', () => {
@@ -141,7 +143,7 @@ describe('summarize', () => {
 });
 
 describe('rendering helpers', () => {
-	// 6 distinct unknown hosts -> exercises the "+N hosts" overflow branch (>5)
+	// 6 distinct unknown hosts -> all are listed (no truncation / 細分表示)
 	const manyUnknown = summarize(
 		['a', 'b', 'c', 'd', 'e', 'f'].map((p) => ({ host: `${p}.evil.ru` })),
 	);
@@ -154,22 +156,30 @@ describe('rendering helpers', () => {
 		expect(classificationSubjectSuffix(onlyGated)).toBe('');
 	});
 
-	it('renderClassificationLines truncates hosts past the cap', () => {
-		const lines = renderClassificationLines(manyUnknown);
-		expect(lines).toHaveLength(1);
-		expect(lines[0]).toContain('❓ 不明 (要確認): 6');
-		expect(lines[0]).toContain('+1 hosts'); // 6 hosts, cap 5
-	});
-
-	it('renderClassificationLines without overflow omits the "+N hosts" suffix', () => {
+	it('always renders all 4 category lines (incl 0-count ⚠️/❓), with 0 → なし', () => {
 		const lines = renderClassificationLines(onlyGated);
-		expect(lines[0]).toContain('✅ CF Access 済み: 1');
-		expect(lines[0]).not.toContain('+');
+		expect(lines).toHaveLength(4);
+		expect(lines[0]).toBe('⚠️ 要 CF Access 検討: 0 — なし');
+		expect(lines[1]).toBe('❓ 不明 (要確認): 0 — なし');
+		expect(lines.find((l) => l.startsWith('✅'))).toContain('✅ CF Access 済み: 1 — alc-staging.ippoan.org (1)');
 	});
 
-	it('renderClassificationMrkdwn bullets lines, falls back when empty', () => {
+	it('lists every host without truncation (細分表示)', () => {
+		const lines = renderClassificationLines(manyUnknown);
+		const unknownLine = lines.find((l) => l.startsWith('❓'))!;
+		expect(unknownLine).toContain('❓ 不明 (要確認): 6');
+		expect(unknownLine).not.toContain('+'); // no "+N hosts" cap
+		for (const p of ['a', 'b', 'c', 'd', 'e', 'f']) {
+			expect(unknownLine).toContain(`${p}.evil.ru (1)`);
+		}
+	});
+
+	it('renderClassificationMrkdwn always bullets all 4 categories', () => {
+		const mrkdwn = renderClassificationMrkdwn(empty);
+		expect(mrkdwn.split('\n')).toHaveLength(4);
+		expect(mrkdwn).toContain('• ⚠️ 要 CF Access 検討: 0 — なし');
+		expect(mrkdwn).toContain('• ❓ 不明 (要確認): 0 — なし');
 		expect(renderClassificationMrkdwn(onlyGated)).toContain('• ✅ CF Access 済み: 1');
-		expect(renderClassificationMrkdwn(empty)).toBe('分類対象なし');
 	});
 
 	it('renderClassificationHtml escapes labels/hosts via injected escaper', () => {
@@ -181,6 +191,7 @@ describe('rendering helpers', () => {
 		const html = renderClassificationHtml(onlyGated, escape);
 		expect(html).toContain('<h3>CF Access 観点の分類</h3>');
 		expect(html).toContain('<b>1</b>');
+		expect((html.match(/<li>/g) || []).length).toBe(4); // all 4 categories
 		expect(calls.length).toBeGreaterThan(0); // escaper was invoked
 	});
 });


### PR DESCRIPTION
## 背景

通知の分類表示について 2 点の要望:
1. ⚠️ 要対応 / ❓ 不明 が 0 件のときも表示したい（現状は 0 件カテゴリを非表示）。
2. 公開 (public) のイベントを host 別に細分して表示したい（現状は上位 5 host + `+N hosts` で省略）。

## 変更（`src/classify.ts`、pure module のみ）

- `summarize()` が **常に 4 カテゴリ全部** (`access-candidate` / `unknown` / `gated` / `public`) を返す。0 件でも bucket を出すので、通知に `⚠️ 要 CF Access 検討: 0` / `❓ 不明 (要確認): 0` が表示される。
- `hostsLine` が **全 host を列挙**（5 件上限 / `+N hosts` 省略を廃止）。public が host 別に全件細分される。0 件カテゴリは `なし`。
- email / Slack / webhook / log は同じ `summarize` を使うため全経路に反映。件名サフィックス（要対応 N）は従来どおり。

## テスト

`npx tsc --noEmit` OK / `npx vitest run --coverage` **85 passed**、`src/classify.ts` coverage **100%**。

Refs #20


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3DCAqQFe1tjjpeQ3z4fHH)_